### PR TITLE
any python module can have sequana_pipelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,7 @@ Changelog
 ========= ======================================================================
 Version   Description
 ========= ======================================================================
+0.10.1    * any python module can implement a Sequana pipeline.
 0.10.0    * incorporate the sequana_start_template from sequana and refactorise
             the scripts into scripts/
 0.9.6     * hotfix on apptainer to be back compatible if no apptainers section

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pykwalify
 importlib_resources
 pyyaml
 aiohttp
+tqdm

--- a/sequana_pipetools/snaketools/module.py
+++ b/sequana_pipetools/snaketools/module.py
@@ -10,7 +10,6 @@
 #  Documentation: http://sequana.readthedocs.io
 #  Contributors:  https://github.com/sequana/sequana/graphs/contributors
 ##############################################################################
-import glob
 import os
 
 import colorlog

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 _MAJOR = 0
 _MINOR = 10
-_MICRO = 0
+_MICRO = 1
 
 version = f"{_MAJOR}.{_MINOR}.{_MICRO}"
 release = f"{_MAJOR}.{_MINOR}"


### PR DESCRIPTION
J'ai "sequana_mergegi" qui n'existe pas comme c'est installer via le package "mergegi".
Et finalement, c'est encore utilisé ce petit bout de code.