### PR TITLE
Fix SLURM memory allocation using mem_mb to avoid space-formatted val…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,6 +335,8 @@ Changelog :memo:
 ========= ======================================================================
 Version   Description
 ========= ======================================================================
+1.5.7     * Fix SLURM sbatch memory allocation using mem_mb instead of mem
+            to avoid "Unable to open file GB" error with space-formatted values
 1.5.6     * Allow duplicate sample names in paired-end read files (2x files
             with same sample name). Enforce uniqueness otherwise.
           * Improve test coverage for FileFactory paired-end handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "sequana_pipetools"
-version = "1.5.6"
+version = "1.5.7"
 description = "A set of tools to help building or using Sequana pipelines"
 authors = [{name="Sequana Team", email="thomas.cokelaer@pasteur.fr"}]
 license = "BSD-3"

--- a/sequana_pipetools/resources/slurm.yaml
+++ b/sequana_pipetools/resources/slurm.yaml
@@ -4,7 +4,7 @@ cluster:
     --partition={{resources.partition}}
     --qos={{resources.qos}}
     --cpus-per-task={{threads}}
-    --mem={{resources.mem}}
+    --mem={{resources.mem_mb}}
     --job-name=smk-{{rule}}-{{wildcards}}
     --output=logs/{{rule}}/{{rule}}-{{wildcards}}-slurm-%j.out
     $(bash -c '[[ ! -z "{{resources.gres}}" ]] && echo "--gres={{resources.gres}}"')

--- a/sequana_pipetools/snaketools/profile.py
+++ b/sequana_pipetools/snaketools/profile.py
@@ -66,7 +66,7 @@ def _build_slurm_config_v7(**kwargs) -> dict:
         "--partition={resources.partition} "
         "--qos={resources.qos} "
         "--cpus-per-task={threads} "
-        "--mem={resources.mem} "
+        "--mem={resources.mem_mb} "
         "--job-name=smk-{rule}-{wildcards} "
         "--output=logs/{rule}/{rule}-{wildcards}-slurm-%j.out "
         '$(bash -c \'[[ ! -z "{resources.gres}" ]] && echo "--gres={resources.gres}"\')'
@@ -137,7 +137,7 @@ def _build_slurm_config_v8(**kwargs) -> dict:
         "--partition={resources.partition} "
         "--qos={resources.qos} "
         "--cpus-per-task={threads} "
-        "--mem={resources.mem} "
+        "--mem={resources.mem_mb} "
         "--job-name=smk-{rule}-{wildcards} "
         "--output=logs/{rule}/{rule}-{wildcards}-slurm-%j.out "
         '$(bash -c \'[[ ! -z "{resources.gres}" ]] && echo "--gres={resources.gres}"\')'


### PR DESCRIPTION
…ue errors

- Replace {resources.mem} with {resources.mem_mb} in sbatch command templates
- mem_mb is in MB without spaces, preventing 'Unable to open file GB' error
- Fixes issue where mem value gets formatted as '4 GB' causing sbatch parse failure
- Update version to 1.5.7